### PR TITLE
Sandbox Nilesoft Only solution

### DIFF
--- a/dev.develop/app.sandbox.nss
+++ b/dev.develop/app.sandbox.nss
@@ -18,7 +18,7 @@ menu(title='Windows Sandbox' mode='single' type='file|dir|back.dir|drive|back.dr
 		cmd-ps=`$wsbConfig='@str.replace(template_b, 'SOURCE', app.dir).replace('TARGET', app.dir).replace('CMD', '@app.exe -s -r')'; @ps_command` window='hidden')
 	item(image=\uE249 keys='SHIFT writable' title='Run Sandbox with NS Shell only'
 		tip='Synchronizes the Nilesoft Shell directory with Windows Sandbox. Only the Nilesoft Shell context menu is enabled. Hold SHIFT to enable writable access.'
-		cmd-ps=`$wsbConfig='@str.replace(template_b, 'SOURCE', app.dir).replace('TARGET', app.dir).replace('CMD', '@app.exe -s -r -t')'; @ps_command` window='hidden')
+		cmd-ps=`$wsbConfig='@str.replace(template_b, 'SOURCE', app.dir).replace('TARGET', app.dir).replace('CMD', '@app.exe -s -u -t -restart ; @app.exe -s -r -t')'; @ps_command` window='hidden')
 	item(image=\uE0E9 keys='SHIFT writable' title='Sync Desktop with Sandbox'
 		tip='Maps your desktop folder into the Windows Sandbox. Hold SHIFT to enable writable access.' 
 		cmd-ps=`$wsbConfig='@str.replace(template_m, 'SOURCE', user.desktop).replace('TARGET', 'C:\Users\WDAGUtilityAccount\Desktop')'; @ps_command` window='hidden')


### PR DESCRIPTION
In latest version of Windows and Sandbox the Nilesoft only method doesn't work. It results in the same thing as the  hybrid option so the Nilesoft menu only shows when you click "show more options". I altered the command so it works properly now but there is a lag waiting for explorer to restart before it the menu shows like it should.